### PR TITLE
Fix/testimonial delete

### DIFF
--- a/src/components/Molecules/Cards/Testimonial/TestimonialPrimaryCard.jsx
+++ b/src/components/Molecules/Cards/Testimonial/TestimonialPrimaryCard.jsx
@@ -3,6 +3,7 @@ import { MdStar } from 'react-icons/md';
 import { useDispatch, useSelector } from 'react-redux';
 import { MdDelete } from 'react-icons/md';
 import { deleteTestimonial } from '../../../../store/Testimonials.slice';
+import { toast } from 'react-toastify';
 
 const renderStars = (count = 0) => {
    return [...Array(5)].map((_, i) => (
@@ -28,10 +29,20 @@ const TestimonialPrimaryCard = ({
 }) => {
    let dispatch = useDispatch();
    const user = useSelector(state => state.auth.user);
+   const { loading } = useSelector((state) => state.testimonials);
 
-   const Handle_Testimonial_Delete = _id => {
-      dispatch(deleteTestimonial({ _id }));
-    
+   const handleTestimonialDelete = () => {
+
+      if (window.confirm('Are you sure you want to delete this testimonial?')) {
+         dispatch(deleteTestimonial(_id))
+            .unwrap()
+            .then(() => {
+               toast.success('Testimonial deleted successfully!'); // Optional: Show success toast
+            })
+            .catch((err) => {
+               toast.error(err || 'Failed to delete testimonial'); // Optional: Show error toast
+            });
+      }
    };
 
    return (
@@ -40,13 +51,15 @@ const TestimonialPrimaryCard = ({
 
       >
          {user?.role === 'admin' && (
-            <div className='w-full h-[5vh] flex items-center justify-end text-[2rem]'>
-               <div
-                  className='bg-black text-white rounded-full p-2 cursor-pointer'
-                  onClick={() => Handle_Testimonial_Delete(_id)}
+            <div className="w-full h-[5vh] flex items-center justify-end text-[2rem]">
+               <button
+                  className="bg-black text-white rounded-full p-2 cursor-pointer"
+                  onClick={handleTestimonialDelete}
+                  disabled={loading}
+                  aria-label="Delete testimonial"
                >
                   <MdDelete />
-               </div>
+               </button>
             </div>
          )}
 

--- a/src/store/Testimonials.slice.js
+++ b/src/store/Testimonials.slice.js
@@ -20,7 +20,23 @@ export const deleteTestimonial = createAsyncThunk(
 const testimonialsSlice = createSlice({
   name: 'testimonials',
   initialState: {
-    testimonials: [],
+    testimonials: [
+    {
+        _id: '1',
+        name: 'Default User 1',
+        testimonial: 'This is a default testimonial 1.',
+        image: 'https://placeholder.com', 
+        job_Role: 'Student',
+        rating: 5
+      },
+      {
+        _id: '2',
+        name: 'Default User 2',
+        testimonial: 'This is a default testimonial 2.',
+        image: 'https://placeholder.com', 
+        job_Role: 'Alumni',
+        rating: 4
+      }],
     loading: false,
     error: null,
   },

--- a/src/store/Testimonials.slice.js
+++ b/src/store/Testimonials.slice.js
@@ -1,27 +1,52 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
 
-const testimonials_Slice = createSlice({
-   name: 'testimonials',
-   initialState: {
-      testimonials: [],
-   },
-   reducers: {
-      setTestimonials_Data: (state, action) => {
-         state.testimonials = action.payload;
-      },
+// Thunk to delete a testimonial
+export const deleteTestimonial = createAsyncThunk(
+  'testimonials/deleteTestimonial',
+  async (testimonialId, { rejectWithValue }) => {
+    try {
+      const { data } = await axios.delete(
+        `/api/v1/deleteTestimonial/${testimonialId}`
+      );
+      return { id: testimonialId, ...data }; 
+    } catch (error) {
+      return rejectWithValue(error.response?.data || 'Failed to delete testimonial');
+    }
+  }
+);
 
-      deleteTestimonial: (state, action) => {
-         console.log('action', action);
-         const find_index = state.testimonials.findIndex(
-            item => item._id === action.payload._id,
-         );
-         if (find_index !== -1) {
-            state.testimonials.splice(find_index, 1);
-         }
-      },
-   },
+
+const testimonialsSlice = createSlice({
+  name: 'testimonials',
+  initialState: {
+    testimonials: [],
+    loading: false,
+    error: null,
+  },
+  reducers: {
+    setTestimonials_Data: (state, action) => {
+      state.testimonials = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(deleteTestimonial.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(deleteTestimonial.fulfilled, (state, action) => {
+        state.loading = false;
+        state.testimonials = state.testimonials.filter(
+          (item) => item._id !== action.payload.id 
+        );
+      })
+      .addCase(deleteTestimonial.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload || 'Failed to delete testimonial';
+      });
+  },
 });
 
-export const { setTestimonials_Data, deleteTestimonial } =
-   testimonials_Slice.actions;
-export default testimonials_Slice.reducer;
+export const { setTestimonials_Data } = testimonialsSlice.actions;
+export default testimonialsSlice.reducer;

--- a/src/store/appStore.js
+++ b/src/store/appStore.js
@@ -11,6 +11,7 @@ import PaymentSlice from './PaymentSlice';
 import AdminUiSlice from './AdminUi';
 import InputSlice from './InputSlice';
 import NavigatorSlice from './NavigatorSlice';
+import testimonialsSlice from './Testimonials.slice'
 
 export const appStore = configureStore({
    reducer: {
@@ -26,5 +27,6 @@ export const appStore = configureStore({
       AdminUi: AdminUiSlice,
       Input: InputSlice,
       Navigator: NavigatorSlice,
+      testimonials: testimonialsSlice,
    },
 });


### PR DESCRIPTION
## Issue Number #221

- this pr closes issue: #221,  Feature Request: Delete Testimonial Functionality via Recycle Bin Icon.

---

## Issue Description 🛠️
Problem: The Testimonial section on the Home page displays a list of testimonial cards, but the Recycle Bin (🗑️) icon did not trigger any delete functionality. Clicking the icon had no effect, and testimonials remained in both the Redux state and the backend.

Cause: The delete logic (Redux thunk + API integration) was not implemented. The UI button was not connected to any action.

Solution (This PR):

Implemented deleteTestimonial thunk in testimonialSlice.js that:

Sends a DELETE request to /api/v1/deleteTestimonial/:id.

Removes the deleted testimonial from the Redux state.

Updated TestimonialCard.jsx to dispatch the thunk on Recycle Bin click.

Added a simple confirmation dialog before deletion to prevent accidental removals.

💡 Problem Solved: Admins can now delete testimonials from both the frontend state and the backend by clicking the Recycle Bin icon.



## Screenshots or Video Demonstration (Optional) 📸

<img width="1357" height="561" alt="Screenshot from 2025-09-24 15-51-56" src="https://github.com/user-attachments/assets/e15123ed-234f-431d-bd95-bafec49b12d5" />

<img width="1357" height="561" alt="Screenshot from 2025-09-24 15-51-23" src="https://github.com/user-attachments/assets/e0fb5d93-6c97-40ba-a803-abb4b4817968" />

<img width="1357" height="561" alt="Screenshot from 2025-09-24 15-51-15" src="https://github.com/user-attachments/assets/32f2cb99-c0d2-4362-b5dc-1e6515ea90b6" />

